### PR TITLE
[44] update create account copy

### DIFF
--- a/ssi/register.html
+++ b/ssi/register.html
@@ -9,7 +9,7 @@
         <div class="col-md-8 col-md-offset-2 col-xs-12">
           <h2>Create Account</h2>
           <div class="oauth button-row center">
-            <a href="#" class="button oauth-button twitter"><i class="fa fa-twitter"></i> Register with Twitter</a> <a href="#" class="button oauth-button facebook"><i class="fa fa-facebook"></i> Register with Facebook</a>
+            <a href="#" class="button oauth-button twitter"><i class="fa fa-twitter"></i> Join with Twitter</a> <a href="#" class="button oauth-button facebook"><i class="fa fa-facebook"></i> Join with Facebook</a>
           </div>
           <p class="or">Or</p>
           <form name="register">
@@ -26,7 +26,7 @@
               <input type="password" name="password_confirmation" placeholder="Confirm Password" />
             </div>
             <div class="button-row right">
-              <input type="submit" value="Register" class="button" />
+              <input type="submit" value="Create Account" class="button" />
             </div>
           </form>
         </div>


### PR DESCRIPTION
Closes #44.

Changing "register" to "create" didn't make sense everywhere ("Create Account with Twitter" started to get kind of unwieldy as a phrase) so I replaced it in some instances with "Join" since that flowed better.