### PR TITLE
[54] Fix secondary menu items returning false on mobile

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -36,10 +36,12 @@
 					$('.hamburger').removeClass('is-active');
 				});
 
-				$('.topnav li.parent a').on('click', function(e) {
+				$('.topnav li.parent > a').on('click', function(e) {
 					if ($(window).width() <= 768) {
 						if ($(this).next('.submenu').not(":visible")) {
 							e.preventDefault();
+							$(this).next('.submenu').slideDown(500);
+							$(this).parent().siblings().find('.submenu').slideUp(500);
 						}
 					}
 				});

--- a/assets/styles/template-parts/_nav.scss
+++ b/assets/styles/template-parts/_nav.scss
@@ -146,6 +146,7 @@
 		font-size: 16px;
 		width: 100%;
 		border-top: 1px $color-ltgray solid;
+		border-bottom: 1px $color-ltgray solid;
 
 		> ul {
 			padding: 0;
@@ -155,6 +156,12 @@
 				width:100%;
 				margin:0;
 				height:auto;
+
+				&:hover {
+					ul.submenu {
+						display: none;
+					}
+				}
 
 				> a {
 					width:100%;
@@ -178,6 +185,9 @@
 					border: none;
 					border-radius: 0;
 					border-bottom: 2px $color-ltgray solid;
+					transform: none;
+					display: none;
+					max-height: none;
 
 					li {
 						border-bottom: 1px $color-ltgray dotted;


### PR DESCRIPTION
Closes #54.

Insufficiently-specific selector (li.parent a instead of li.parent > a) caused secondary menu items to prevent default action instead of allowing link click. Also made a few adjustments to functioning of nav menu on mobile for better UX experience (click to expand menus rather than hover to prevent jumpiness).