### PR TITLE
[69] switch to white background on blog entries, add divider between items

### DIFF
--- a/assets/styles/templates/_blog-index.scss
+++ b/assets/styles/templates/_blog-index.scss
@@ -1,6 +1,17 @@
 .page-template-template-blog-index {
   .blog-entry {
-    margin-bottom: 60px;
+    padding-top: 30px;
+    padding-bottom: 30px;
+    border-bottom: 1px solid $color-ltgray;
+
+    &:first-child {
+      padding-top: 0;
+    }
+
+    &:last-child {
+      padding-bottom: 0;
+      border-bottom: none;
+    }
 
     h2 {
       margin-bottom: 20px;
@@ -14,12 +25,7 @@
       margin-top: 30px;
 
       a {
-        color: white;
         text-decoration: underline;
-
-        &:hover {
-          color: black;
-        }
       }
     }
   }

--- a/ssi/blog-index.html
+++ b/ssi/blog-index.html
@@ -11,7 +11,7 @@
   <div class="banner-overlay"></div>
   <div class="banner"></div>
 </section>
-<section id="blog-list" class="section sidebyside gradient">
+<section id="blog-list" class="section sidebyside">
   <div class="wrapper blog-entry">
     <div class="row middle-xs">
       <div class="col-md-3 col-xs-12">


### PR DESCRIPTION
Closes #69.

Looks like this:
![screencapture-localhost-8080-blog-index-html-1508381028552](https://user-images.githubusercontent.com/267841/31751873-8a6d0c66-b44d-11e7-9f34-a13442f24acb.png)
